### PR TITLE
Bump 'rss' package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         }
     ],
     "dependencies": {
-        "rss": "~0.3.2"
+        "rss": "~1.2.2"
     },
     "keywords": [
         "blog",


### PR DESCRIPTION
[`rss` is vulnerable to a ReDoS attack](https://snyk.io/test/npm/rss/0.3.2).
Updated it to the most recent version, which fixes the issue.